### PR TITLE
feat(?): require login to find match

### DIFF
--- a/client/src/components/MatchmakingComponent.jsx
+++ b/client/src/components/MatchmakingComponent.jsx
@@ -1,21 +1,31 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 
 import Button from 'react-bootstrap/Button';
 
 import { findMatch } from '@/lib/matchmaking';
 
-const FindGameButton = () => {
+const propTypes = {
+  username: PropTypes.string
+};
+
+const FindGameButton = ({ username }) => {
   const [ buttonState, setButtonState ] = useState({ disabled: false, text: 'Find Match' });
 
-  const onClickFn = () => {
-    setButtonState({ disabled: true, text: 'Finding...' });
-    findMatch(setButtonState);
+  const onClickFn = (username) => {
+    if (username) {
+      setButtonState({ disabled: true, text: 'Finding...' });
+      findMatch(setButtonState);
+    } else {
+      setButtonState({ disabled: false, text: 'You are not logged in!'});
+    }
+
   };
 
   return (
     <>
       <Button
-        onClick={onClickFn}
+        onClick={() => onClickFn(username)}
         variant="dark"
         type="submit"
         block
@@ -26,5 +36,7 @@ const FindGameButton = () => {
     </>
   );
 };
+
+FindGameButton.propTypes = propTypes;
 
 export default FindGameButton;

--- a/client/src/pages/index.jsx
+++ b/client/src/pages/index.jsx
@@ -23,7 +23,7 @@ const Home = (props) => {
         <title>{siteTitle}</title>
       </Head>
       <section>
-        <MatchmakingComponent />
+        <MatchmakingComponent username={username} />
       </section>
     </Layout>
   );


### PR DESCRIPTION
Only temporarily. Currently, IP address is used as an alternative if the user isn't logged in. However, because of how the nginx config is currently set, it's using the IP address of the localhost, that is, it's constantly the same.
I'd rather change(?) the whole authentication system to make use of cookies for guests instead of fixing nginx so as a temporary fix, an account is required.