### PR TITLE
fix: separate the ping made by spectators

### DIFF
--- a/client/src/components/Game/index.jsx
+++ b/client/src/components/Game/index.jsx
@@ -46,6 +46,7 @@ const Game = (props) =>{
   const moveRef = useRef();
   const vsRef = useRef();
   const [statusPingDelay, clearStatusPingDelay] = useDelay(5);
+  const [spectatorStatusPingDelay, clearSpectatorStatusPingDelay] = useDelay(15);
   const [botMoveDelay, clearBotMoveDelay] = useDelay(1.5);
 
   useEffect(() => {
@@ -106,13 +107,18 @@ const Game = (props) =>{
       statusIndicatorSocket.onmessage = async (message) => {
         const res = JSON.parse(message.data);
         clearStatusPingDelay();
+        clearSpectatorStatusPingDelay();
 
         if (res.connections.length !== connections.list.length) {
           setConnections({ list: res.connections, retry: !connections.retry });
         }
-
-        await statusPingDelay();
-
+        
+        if (gameState.player) {
+          await statusPingDelay();
+        } else {
+          await spectatorStatusPingDelay();
+        }
+          
         statusIndicatorSocket.send(JSON.stringify({
           type: 'ping',
         }));


### PR DESCRIPTION
It's not necessary for spectators to ping at the same time as the
players for the status indicator. The spectators should only ping the
server for the status of the players if the players haven't sent a ping
past 5 seconds, meaning they both disconnected.