### PR TITLE
fix: change socket.cn value

### DIFF
--- a/api/src/ws/game.ts
+++ b/api/src/ws/game.ts
@@ -11,7 +11,14 @@ import SendSocketMessage from './socketMessages';
 import { IUpgrade, IOpen, IClose, IMessage, WS_RESPONSE_CODE } from './types';
 
 export const upgrade: IUpgrade<Promise<void>> = async (res, req, context) => {
-  const cn = await getUsername(req.getHeader('cookie'));
+  const user = await getUsername(req.getHeader('cookie'));
+
+  // get IP address (getRemoteAddress is unnecessary in deployment)
+  const IP = req.getHeader('y-real-ip') || decode(res.getRemoteAddress());
+
+  // if there is no cookie, use the IP address as identifier
+  const cn = user || IP;
+
   const url = req.getParameter(0);
 
   const checks = [(req.getHeader('origin') === config.CLIENT_HOST)];


### PR DESCRIPTION
Use the IP address of the user if the user has no cookie. This is
necessary for users who directly visit a game link instead of going
through the index page to get a cookie. The useCookie hook can be
included but it wouldn't work anyway because the socket connects to the
WS server immediately, before the useCookie hook can attach the cookie
to the browser.

It's not that big of a deal because what will just happen
is that if you gave your PIN to someone else, if he tries to spectate
your game, everyone with the same address will be able to see your
board. I should probably fix it regardless, but maybe next time...